### PR TITLE
Fix cross-platform vite scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "dark-portfolio",
   "version": "1.0.0",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview"
+    "dev": "node node_modules/vite/bin/vite.js",
+    "build": "node node_modules/vite/bin/vite.js build",
+    "preview": "node node_modules/vite/bin/vite.js preview"
   },
   "dependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- update npm scripts to invoke vite via Node so dev/build preview run on any platform

## Testing
- `npm run build` *(fails: esbuild for win32 present)*

------
https://chatgpt.com/codex/tasks/task_e_68655686501c8326a6171bf92710f646